### PR TITLE
refactor: move business logic to service 

### DIFF
--- a/src/backend/src/infrastructure/database/connection.js
+++ b/src/backend/src/infrastructure/database/connection.js
@@ -51,6 +51,12 @@ export class DatabaseConnection {
     });
   }
 
+  /**
+   *
+   * @param {string} queryString
+   * @param {any[]} params
+   * @returns {Promise<any>}
+   */
   async queryOne(queryString, params = []) {
     return new Promise((resolve, reject) => {
       this.db.get(queryString, params, (err, row) => {

--- a/src/backend/src/infrastructure/database/queries/platforms/findOnePlatformByName.js
+++ b/src/backend/src/infrastructure/database/queries/platforms/findOnePlatformByName.js
@@ -1,0 +1,3 @@
+export const findOnePlatformByNameQuery = `
+  SELECT * FROM platforms WHERE name = ?;
+`;

--- a/src/backend/src/modules/platform/platformController.js
+++ b/src/backend/src/modules/platform/platformController.js
@@ -51,9 +51,7 @@ export class PlatformsController {
        * @param {FindOnePlatformDto} req.params
        */
       const { id } = req.params;
-
       const result = await this.service.findOne(Number(id));
-
       res.status(200).json(result);
     } catch (err) {
       next(err);
@@ -73,7 +71,6 @@ export class PlatformsController {
        * @type {UpdatePlatformDto}
        */
       const { name } = req.body;
-
       const result = await this.service.update({ id: Number(id), name });
       res.status(200).json(result);
     } catch (err) {

--- a/src/backend/src/modules/platform/platformController.js
+++ b/src/backend/src/modules/platform/platformController.js
@@ -18,81 +18,82 @@ export class PlatformsController {
    * @type {import('express').RequestHandler}
    */
   async create(req, res, next) {
-    /**
-     * @type {CreatePlatformDto}
-     */
-    const platformDto = req.body;
-    const result = await this.service.create(platformDto);
-    res.status(201).json(result);
+    try {
+      /**
+       * @type {CreatePlatformDto}
+       */
+      const platformDto = req.body;
+      const result = await this.service.create(platformDto);
+      res.status(201).json(result);
+    } catch (err) {
+      next(err);
+    }
   }
 
   /**
    * @type {import('express').RequestHandler}
    */
   async find(req, res, next) {
-    const result = await this.service.find();
-    res.status(200).json(result);
+    try {
+      const result = await this.service.find();
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
+    }
   }
 
   /**
    * @type { import('express').RequestHandler}
    */
   async findOne(req, res, next) {
-    /**
-     * @param {FindOnePlatformDto} req.params
-     */
-    const { id } = req.params;
+    try {
+      /**
+       * @param {FindOnePlatformDto} req.params
+       */
+      const { id } = req.params;
 
-    const result = await this.service.findOne({ id: Number(id) });
-    if (!result) {
-      res.status(404).json({ message: "Not found!" });
-      return;
+      const result = await this.service.findOne(Number(id));
+
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
     }
-    res.status(200).json(result);
   }
 
   /**
    * @type { import('express').RequestHandler}
    */
   async update(req, res, next) {
-    /**
-     * @param {FindOnePlatformDto} req.params
-     */
-    const { id } = req.params;
-    /**
-     * @type {UpdatePlatformDto}
-     */
-    const { name } = req.body;
+    try {
+      /**
+       * @param {FindOnePlatformDto} req.params
+       */
+      const { id } = req.params;
+      /**
+       * @type {UpdatePlatformDto}
+       */
+      const { name } = req.body;
 
-    const result = await this.service.update({ id: Number(id), name });
-    if (!result) {
-      res.status(404).json({ message: "Not found!" });
-      return;
+      const result = await this.service.update({ id: Number(id), name });
+      res.status(200).json(result);
+    } catch (err) {
+      next(err);
     }
-    if (result.name === name) {
-      res.status(400).json({
-        message:
-          "Bad Request! You cannot change the platform name to the same name!",
-      });
-      return;
-    }
-    res.status(200).json(result);
   }
 
   /**
    * @type { import('express').RequestHandler}
    */
   async delete(req, res, next) {
-    /**
-     * @param {FindOnePlatformDto} req.params
-     */
-    const { id } = req.params;
-
-    const result = await this.service.delete({ id: Number(id) });
-    if (!result) {
-      res.status(404).json({ message: "Not found!" });
-      return;
+    try {
+      /**
+       * @param {FindOnePlatformDto} req.params
+       */
+      const { id } = req.params;
+      const result = await this.service.delete(Number(id));
+      res.status(204).send(result);
+    } catch (err) {
+      next(err);
     }
-    res.status(204).send();
   }
 }

--- a/src/backend/src/modules/platform/platformRepository.js
+++ b/src/backend/src/modules/platform/platformRepository.js
@@ -8,6 +8,7 @@ import { findPlatformsQuery } from "../../infrastructure/database/queries/platfo
 import { findOnePlatformQuery } from "../../infrastructure/database/queries/platforms/findOnePlatform.js";
 import { updatePlatformQuery } from "../../infrastructure/database/queries/platforms/updatePlatform.js";
 import { deletePlatformQuery } from "../../infrastructure/database/queries/platforms/deletePlatform.js";
+import { findOnePlatformByNameQuery } from "../../infrastructure/database/queries/platforms/findOnePlatformByName.js";
 export class PlatformsRepository {
   /**
    * @constructor
@@ -28,10 +29,18 @@ export class PlatformsRepository {
     return await this.db.query(findPlatformsQuery);
   }
   /**
-   * @param {FindOnePlatformDto} FindOnePlatformDto
+   * @param {number} id
    */
-  async findOne({ id }) {
+  async findOne(id) {
     const result = await this.db.query(findOnePlatformQuery, [id]);
+    return result[0];
+  }
+
+  /**
+   * @param {string} name
+   */
+  async findOneByName(name) {
+    const result = await this.db.query(findOnePlatformByNameQuery, [name]);
     return result[0];
   }
 
@@ -44,9 +53,9 @@ export class PlatformsRepository {
   }
 
   /**
-   * @param {deletePlatformDto} deletePlatformDto
+   * @param {number} id
    */
-  async delete({ id }) {
+  async delete(id) {
     const result = this.db.query(deletePlatformQuery, [id]);
     return result;
   }

--- a/src/backend/src/modules/platform/platformRepository.js
+++ b/src/backend/src/modules/platform/platformRepository.js
@@ -32,16 +32,14 @@ export class PlatformsRepository {
    * @param {number} id
    */
   async findOne(id) {
-    const result = await this.db.query(findOnePlatformQuery, [id]);
-    return result[0];
+    return await this.db.queryOne(findOnePlatformQuery, [id]);
   }
 
   /**
    * @param {string} name
    */
   async findOneByName(name) {
-    const result = await this.db.query(findOnePlatformByNameQuery, [name]);
-    return result[0];
+    return this.db.queryOne(findOnePlatformByNameQuery, [name]);
   }
 
   /**

--- a/src/backend/src/modules/platform/platformService.js
+++ b/src/backend/src/modules/platform/platformService.js
@@ -18,6 +18,14 @@ export class PlatformsService {
    * @returns
    */
   async create({ name }) {
+    console.log({ name });
+    const existingPlatform = await this.repository.findOneByName(name);
+    if (existingPlatform) {
+      throw {
+        status: 400,
+        message: "Bad Request! Platform already exists!",
+      };
+    }
     return this.repository.create({
       name,
     });
@@ -31,37 +39,58 @@ export class PlatformsService {
   }
 
   /**
-   * @param {FindOnePlatformDto} FindOnePlatformDto
+   * @param {number} id
    */
-  async findOne({ id }) {
-    const result = await this.repository.findOne({ id });
-    return result;
+  async findOne(id) {
+    const platform = await this.repository.findOne(id);
+    if (!platform) {
+      throw {
+        status: 404,
+        message: "Not found!",
+      };
+    }
+    return platform;
+  }
+
+  /**
+   * @param {string} name
+   */
+  async findOneByName(name) {
+    return this.repository.findOneByName(name);
   }
 
   /**
    * @param {UpdatePlatformDto} UpdatePlatformDto
    */
   async update({ id, name }) {
-    const foundPlatform = await this.repository.findOne({ id });
-    if (!foundPlatform || foundPlatform.name === name) {
-      return foundPlatform;
+    const foundPlatform = await this.repository.findOne(id);
+    if (!foundPlatform) {
+      throw {
+        status: 404,
+        message: "Not found!",
+      };
     }
-    Object.assign(foundPlatform, {
-      name,
-    });
-    const updatedPlatform = await this.repository.update({ id, name });
-    return updatedPlatform;
+    if (foundPlatform.name === name) {
+      throw {
+        status: 400,
+        message:
+          "Bad Request! You cannot change the platform name to the same name!",
+      };
+    }
+    return await this.repository.update({ id, name });
   }
 
   /**
-   * @param {deletePlatformDto} deletePlatformDto
+   * @param {number} id
    */
-  async delete({ id }) {
-    const foundPlatform = await this.repository.findOne({ id });
+  async delete(id) {
+    const foundPlatform = await this.repository.findOne(id);
     if (!foundPlatform) {
-      return foundPlatform;
+      throw {
+        status: 404,
+        message: "Not found!",
+      };
     }
-    await this.repository.delete({ id });
-    return foundPlatform;
+    return this.repository.delete(id);
   }
 }

--- a/src/backend/src/modules/platform/platformService.js
+++ b/src/backend/src/modules/platform/platformService.js
@@ -18,7 +18,6 @@ export class PlatformsService {
    * @returns
    */
   async create({ name }) {
-    console.log({ name });
     const existingPlatform = await this.repository.findOneByName(name);
     if (existingPlatform) {
       throw {


### PR DESCRIPTION
Esse PR move a regra de negócio pra dentro do service, deixando apenas a chamada pro service dentro dos controllers. 
Ao invés de retornar os erros diretamente dentro da própria função, passamos a jogar erros dentro do service, para que sejam tratados pelo middleware de tratamento de erros.