### PR TITLE
refactor: remove jsdoc types

### DIFF
--- a/src/backend/src/app.js
+++ b/src/backend/src/app.js
@@ -8,10 +8,6 @@ import { errorHandlingMiddleware } from "./middleware/errorHandling.js";
 import { usersModule } from "./modules/user/usersModule.js";
 import { gradesModule } from "./modules/grade/gradeModule.js";
 export class App {
-  /**
-   *
-   * @param {DatabaseConnection} db
-   */
   constructor(db) {
     this.db = db;
     this.app = express();

--- a/src/backend/src/exceptions/httpError.js
+++ b/src/backend/src/exceptions/httpError.js
@@ -1,8 +1,4 @@
 export class HttpError extends Error {
-  /**
-   * @param {number} statusCode
-   * @param {string} message
-   */
   constructor(statusCode, message) {
     super(message);
     this.statusCode = statusCode;

--- a/src/backend/src/exceptions/validationError.js
+++ b/src/backend/src/exceptions/validationError.js
@@ -1,8 +1,4 @@
 export class ValidationError extends Error {
-  /**
-   * @param {string} message
-   * @param {Record<string, string>} errors
-   */
   constructor(message, errors) {
     super(message);
     this.errors = errors;

--- a/src/backend/src/infrastructure/database/connection.js
+++ b/src/backend/src/infrastructure/database/connection.js
@@ -1,25 +1,11 @@
-// @ts-check
-
 import sqlite from "sqlite3";
 import { init } from "./queries/migrations/init.js";
 import { fixtures } from "./queries/fixtures/fixtures.js";
 
-/**
- * @typedef {object} QueryResult
- * @property {number} id
- * @property {number} changes
- */
-
 export class DatabaseConnection {
-  /**
-   * @type {DatabaseConnection}
-   */
   static __instance;
   static __isInternalConstructing = false;
 
-  /**
-   * @param {string} connString
-   */
   constructor(connString) {
     if (!DatabaseConnection.__isInternalConstructing) {
       throw new Error("Cannot instantiate singleton class using constructor");
@@ -34,11 +20,6 @@ export class DatabaseConnection {
     DatabaseConnection.__isInternalConstructing = false;
   }
 
-  /**
-   *
-   * @param {string} connString
-   * @returns
-   */
   static getInstance(connString) {
     if (DatabaseConnection.__instance) {
       return DatabaseConnection.__instance;
@@ -48,11 +29,6 @@ export class DatabaseConnection {
     return this.__instance;
   }
 
-  /**
-   * @param {string} queryString
-   * @param {any[]} params
-   * @returns {Promise<QueryResult>}
-   */
   async exec(queryString, params = []) {
     return new Promise((resolve, reject) => {
       this.db.run(queryString, params, function (err) {
@@ -65,11 +41,6 @@ export class DatabaseConnection {
     });
   }
 
-  /**
-   * @param {string} queryString
-   * @param {any[]} params
-   * @returns {Promise<any[]>}
-   */
   async query(queryString, params = []) {
     return new Promise((resolve, reject) => {
       this.db.all(queryString, params, (err, rows) => {
@@ -82,12 +53,6 @@ export class DatabaseConnection {
     });
   }
 
-  /**
-   *
-   * @param {string} queryString
-   * @param {any[]} params
-   * @returns {Promise<any>}
-   */
   async queryOne(queryString, params = []) {
     return new Promise((resolve, reject) => {
       this.db.get(queryString, params, (err, row) => {

--- a/src/backend/src/main.js
+++ b/src/backend/src/main.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 import { App } from "./app.js";
 import { DatabaseConnection } from "./infrastructure/database/connection.js";
 

--- a/src/backend/src/middleware/errorHandling.js
+++ b/src/backend/src/middleware/errorHandling.js
@@ -1,11 +1,3 @@
-/**
- *
- * @param {Error} error
- * @param {import ('express').Request} req
- * @param {import ('express').Response} res
- * @param {import ('express').NextFunction} res
- * @returns
- */
 export const errorHandlingMiddleware = (error, req, res, next) => {
   console.error({ error });
   if (error.status) {

--- a/src/backend/src/middleware/validation.js
+++ b/src/backend/src/middleware/validation.js
@@ -1,16 +1,3 @@
-// @ts-check
-
-/**
- * @typedef {function} ValidationFunction
- * @param {any} body
- * @returns {void}
- */
-
-/**
- *
- * @param {ValidationFunction} validationFunction
- * @returns {import("express").RequestHandler}
- */
 export const validationMiddleware = (validationFunction) => {
   return async (req, res, next) => {
     try {

--- a/src/backend/src/modules/game/dto/associateGamePlatformDto.js
+++ b/src/backend/src/modules/game/dto/associateGamePlatformDto.js
@@ -1,6 +1,0 @@
-/**
- * @typedef {Object} AssociateGamePlatformDto
- * @property {number} platform_id
- * @property {number} game_id
-
- */

--- a/src/backend/src/modules/game/dto/createGameDto.js
+++ b/src/backend/src/modules/game/dto/createGameDto.js
@@ -1,9 +1,0 @@
-/**
- * @typedef {Object} CreateGameDto
- * @property {string} title
- * @property {string} genre
- * @property {number} price
- * @property {string} developed_by
- * @property {string} release_date
- * @property {number} platform_id
- */

--- a/src/backend/src/modules/game/dto/disassociateGamePlatformDto.js
+++ b/src/backend/src/modules/game/dto/disassociateGamePlatformDto.js
@@ -1,6 +1,0 @@
-/**
- * @typedef {Object} DisassociateGamePlatformDto
- * @property {number} platform_id
- * @property {number} game_id
-
- */

--- a/src/backend/src/modules/game/dto/updateGameDto.js
+++ b/src/backend/src/modules/game/dto/updateGameDto.js
@@ -1,8 +1,0 @@
-/**
- * @typedef {Object} UpdateGameDto
- * @property {string} title
- * @property {string} genre
- * @property {number} price
- * @property {string} developed_by
- * @property {string} release_date
- */

--- a/src/backend/src/modules/game/gameController.js
+++ b/src/backend/src/modules/game/gameController.js
@@ -1,25 +1,10 @@
-// @ts-check
-
-import "./dto/createGameDto.js";
-import { GamesService } from "./gameService.js";
-
 export class GamesController {
-  /**
-   *
-   * @param {GamesService} service
-   */
   constructor(service) {
     this.service = service;
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async create(req, res, next) {
     try {
-      /**
-       * @type {CreateGameDto}
-       */
       const gameDto = req.body;
       const result = await this.service.create(gameDto);
       res.status(201).json(result);
@@ -28,9 +13,6 @@ export class GamesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async find(req, res, next) {
     try {
       const result = await this.service.find();
@@ -50,9 +32,6 @@ export class GamesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async findOne(req, res, next) {
     try {
       const { id } = req.params;
@@ -63,9 +42,6 @@ export class GamesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async delete(req, res, next) {
     try {
       const { id } = req.params;
@@ -76,9 +52,6 @@ export class GamesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async update(req, res, next) {
     try {
       const { id } = req.params;

--- a/src/backend/src/modules/game/gameModel.js
+++ b/src/backend/src/modules/game/gameModel.js
@@ -1,19 +1,4 @@
-// @ts-check
-
-/**
- * @typedef {Object} GameProps;
- * @property {number} id
- * @property {string} title
- * @property {string} genre
- * @property {number} price
- * @property {string} developed_by
- * @property {string} release_date
- */
 class Game {
-  /**
-   *
-   * @param {GameProps} props
-   */
   constructor({ id, title, genre, price, developed_by, release_date }) {
     this.id = id;
     this.title = title;

--- a/src/backend/src/modules/game/gameModule.js
+++ b/src/backend/src/modules/game/gameModule.js
@@ -1,16 +1,9 @@
-// @ts-check
-
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
 import { PlatformsRepository } from "../platform/platformRepository.js";
 import { GamesController } from "./gameController.js";
 import { GamesRepository } from "./gameRepository.js";
 import { gamesRoutes } from "./gameRoutes.js";
 import { GamesService } from "./gameService.js";
 
-/**
- *
- * @param {DatabaseConnection} db
- */
 export const gamesModule = (db) => {
   const gamesRepository = new GamesRepository(db);
   const platformsRepository = new PlatformsRepository(db);

--- a/src/backend/src/modules/game/gameRepository.js
+++ b/src/backend/src/modules/game/gameRepository.js
@@ -1,34 +1,17 @@
-// @ts-check
-
-import "./dto/createGameDto.js";
-import "./dto/updateGameDto.js";
-import "./dto/associateGamePlatformDto.js";
-import "./dto/disassociateGamePlatformDto.js";
-import { createGameQuery } from "./queries/createGame.js";
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
-import { listGames } from "./queries/findGames.js";
-import { findOneGameQuery } from "./queries/findOneGame.js";
-import { deleteGameQuery } from "./queries/deleteGame.js";
-import { updateGameQuery } from "./queries/updateGame.js";
 import { createGamePlatformQuery } from "../common/queries/createGamePlatform.js";
-import { findOneGameByTitleQuery } from "./queries/findOneGameByTitle.js";
 import { deleteGamePlatformQuery } from "../common/queries/deleteGamePlatform.js";
-import Game from "./gameModel.js";
+import { createGameQuery } from "./queries/createGame.js";
+import { deleteGameQuery } from "./queries/deleteGame.js";
+import { listGames } from "./queries/findGames.js";
 import { findGamesByPlatformIdQuery } from "./queries/findGamesByPlatformId.js";
+import { findOneGameQuery } from "./queries/findOneGame.js";
+import { findOneGameByTitleQuery } from "./queries/findOneGameByTitle.js";
+import { updateGameQuery } from "./queries/updateGame.js";
 export class GamesRepository {
-  /**
-   *
-   * @constructor
-   * @param {DatabaseConnection} db
-   */
   constructor(db) {
     this.db = db;
   }
 
-  /**
-   *
-   * @param {CreateGameDto} createGameDto
-   */
   async create({
     title,
     genre,
@@ -51,62 +34,34 @@ export class GamesRepository {
     return createGameResult;
   }
 
-  /**
-   *
-   * @returns {Promise<Game[]>}
-   */
   async find() {
     return this.db.query(listGames);
   }
 
-  /**
-   *
-   * @param {number} platformId
-   */
   async findByPlatform(platformId) {
     return this.db.query(findGamesByPlatformIdQuery, [platformId]);
   }
 
-  /**
-   *
-   * @param {AssociateGamePlatformDto} AssociateGamePlatformDto
-   */
   async associate({ game_id, platform_id }) {
     return this.db.exec(createGamePlatformQuery, [game_id, platform_id]);
   }
-  /**
-   *
-   * @param {DisassociateGamePlatformDto} DisassociateGamePlatformDto
-   */
+
   async disassociate({ game_id, platform_id }) {
     return this.db.exec(deleteGamePlatformQuery, [game_id, platform_id]);
   }
-  /**
-   * @param {number} id
-   * @returns {Promise<Game>}
-   */
+
   async findOne(id) {
     return this.db.queryOne(findOneGameQuery, [id]);
   }
-  /**
-   * @param {string} title
-   * @returns {Promise<Game>}
-   */
+
   async findOneByTitle(title) {
     return this.db.queryOne(findOneGameByTitleQuery, [title]);
   }
 
-  /**
-   * @param {number} id
-   */
   async delete(id) {
     return this.db.exec(deleteGameQuery, [id]);
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdateGameDto} updateGameDto
-   */
   async update(id, { title, genre, price, developed_by, release_date }) {
     return this.db.exec(updateGameQuery, [
       title,

--- a/src/backend/src/modules/game/gameRoutes.js
+++ b/src/backend/src/modules/game/gameRoutes.js
@@ -1,11 +1,6 @@
-// @ts-check
-
 import { Router } from "express";
 import { GamesController } from "./gameController.js";
 
-/**
- * @param {GamesController} controller
- */
 export const gamesRoutes = (controller) => {
   const router = Router();
   router

--- a/src/backend/src/modules/game/gameService.js
+++ b/src/backend/src/modules/game/gameService.js
@@ -1,27 +1,11 @@
-// @ts-check
-
 import { HttpError } from "../../exceptions/httpError.js";
-import { PlatformsRepository } from "../platform/platformRepository.js";
-import "./dto/associateGamePlatformDto.js";
-import "./dto/createGameDto.js";
-import "./dto/disassociateGamePlatformDto.js";
-import "./dto/updateGameDto.js";
-import { GamesRepository } from "./gameRepository.js";
 
 export class GamesService {
-  /**
-   *
-   * @param {GamesRepository} gameRepository
-   * @param {PlatformsRepository} platformRepository
-   */
   constructor(gameRepository, platformRepository) {
     this.gameRepository = gameRepository;
     this.platformRepository = platformRepository;
   }
 
-  /**
-   * @param {CreateGameDto} createGameDto
-   */
   async create(createGameDto) {
     const existingGame = await this.gameRepository.findOneByTitle(
       createGameDto.title,
@@ -42,18 +26,10 @@ export class GamesService {
     return this.gameRepository.find();
   }
 
-  /**
-   *
-   * @param {number} platformId
-   */
   async findByPlatform(platformId) {
     return this.gameRepository.findByPlatform(platformId);
   }
 
-  /**
-   *
-   * @param {number} id
-   */
   async findOne(id) {
     const game = await this.gameRepository.findOne(id);
     if (!game) {
@@ -62,9 +38,6 @@ export class GamesService {
     return game;
   }
 
-  /**
-   * @param {string} title
-   */
   async findOneByTitle(title) {
     const game = await this.gameRepository.findOneByTitle(title);
     if (!game) {
@@ -73,19 +46,11 @@ export class GamesService {
     return game;
   }
 
-  /**
-   *
-   * @param {number} id
-   */
   async delete(id) {
     await this.findOne(id);
     return this.gameRepository.delete(id);
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdateGameDto} updateGameDto
-   */
   async update(id, updateGameDto) {
     const game = await this.findOneByTitle(updateGameDto.title);
     if (game.title === updateGameDto.title) {

--- a/src/backend/src/modules/grade/dto/createGradeDto.js
+++ b/src/backend/src/modules/grade/dto/createGradeDto.js
@@ -1,6 +1,0 @@
-/**
- * @typedef {Object} CreateGradeDto
- * @property {number} userId
- * @property {number} gameId
- * @property {number} grade
- */

--- a/src/backend/src/modules/grade/dto/updateGradeDto.js
+++ b/src/backend/src/modules/grade/dto/updateGradeDto.js
@@ -1,4 +1,0 @@
-/**
- * @typedef {Object} UpdateGradeDto
- * @property {number} grade
- */

--- a/src/backend/src/modules/grade/gradeController.js
+++ b/src/backend/src/modules/grade/gradeController.js
@@ -1,18 +1,8 @@
-// @ts-check
-
-import { GradesService } from "./gradeService.js";
-
 export class GradesController {
-  /**
-   * @param {GradesService} service
-   */
   constructor(service) {
     this.service = service;
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async find(req, res, next) {
     try {
       const grades = await this.service.find();
@@ -22,9 +12,6 @@ export class GradesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async findOne(req, res, next) {
     try {
       const { id } = req.params;
@@ -36,9 +23,6 @@ export class GradesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async findGradesByUser(req, res, next) {
     try {
       const { userId } = req.params;
@@ -49,9 +33,6 @@ export class GradesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async create(req, res, next) {
     try {
       const grade = await this.service.create(req.body);
@@ -61,9 +42,6 @@ export class GradesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async update(req, res, next) {
     try {
       const { id } = req.params;
@@ -74,9 +52,6 @@ export class GradesController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async delete(req, res, next) {
     try {
       const { id } = req.params;

--- a/src/backend/src/modules/grade/gradeModel.js
+++ b/src/backend/src/modules/grade/gradeModel.js
@@ -1,16 +1,4 @@
-// @ts-check
-
-/**
- * @typedef {object} GradeProps
- * @property {number} userId
- * @property {number} gameId
- * @property {number} grade
- */
-
 class Grade {
-  /**
-   * @param {GradeProps} props
-   */
   constructor(props) {
     this.userId = props.userId;
     this.gameId = props.gameId;

--- a/src/backend/src/modules/grade/gradeModule.js
+++ b/src/backend/src/modules/grade/gradeModule.js
@@ -1,6 +1,3 @@
-// @ts-check
-
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
 import { GamesRepository } from "../game/gameRepository.js";
 import { UsersRepository } from "../user/userRepository.js";
 import { GradesController } from "./gradeController.js";
@@ -8,10 +5,6 @@ import { GradesRepository } from "./gradeRepository.js";
 import { gradesRoutes } from "./gradeRoutes.js";
 import { GradesService } from "./gradeService.js";
 
-/**
- *
- * @param {DatabaseConnection} db
- */
 export const gradesModule = (db) => {
   const gradesRepository = new GradesRepository(db);
   const usersRepository = new UsersRepository(db);

--- a/src/backend/src/modules/grade/gradeRepository.js
+++ b/src/backend/src/modules/grade/gradeRepository.js
@@ -1,68 +1,36 @@
-// @ts-check
-
-import "./dto/createGradeDto.js";
-import "./dto/updateGradeDto.js";
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
 import { createGradeQuery } from "./queries/createGrade.js";
 import { deleteGradeQuery } from "./queries/deleteGrade.js";
 import { findGradesQuery } from "./queries/findGrades.js";
 import { findGradesByUserIdQuery } from "./queries/findGradesByUserId.js";
 import { findOneGradeQuery } from "./queries/findOneGrade.js";
 import { updateGradeQuery } from "./queries/updateGrade.js";
-import Grade from "./gradeModel.js";
 
 export class GradesRepository {
-  /**
-   * @constructor
-   * @param {DatabaseConnection} db
-   */
   constructor(db) {
     this.db = db;
   }
 
-  /**
-   * @param {CreateGradeDto} CreatePlatformDto
-   */
   async create({ userId, gameId, grade }) {
     return await this.db.exec(createGradeQuery, [userId, gameId, grade]);
   }
 
-  /**
-   *
-   * @returns {Promise<Grade[]>}
-   */
   async find() {
     return await this.db.query(findGradesQuery);
   }
 
-  /**
-   * @param {number} id
-   * @returns {Promise<Grade>}
-   */
   async findOne(id) {
     return await this.db.queryOne(findOneGradeQuery, [id]);
   }
 
-  /**
-   * @param {number} userId
-   * @returns {Promise<Grade[]>}
-   */
   async findGradesByUser(userId) {
     return this.db.query(findGradesByUserIdQuery, [userId]);
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdateGradeDto} UpdatePlatformDto
-   */
   async update(id, { grade }) {
     const result = await this.db.exec(updateGradeQuery, [grade, id]);
     return result;
   }
 
-  /**
-   * @param {number} id
-   */
   async delete(id) {
     const result = this.db.query(deleteGradeQuery, [id]);
     return result;

--- a/src/backend/src/modules/grade/gradeRoutes.js
+++ b/src/backend/src/modules/grade/gradeRoutes.js
@@ -1,10 +1,5 @@
-// @ts-check
-import { GradesController } from "./gradeController.js";
 import { Router } from "express";
 
-/**
- * @param {GradesController} controller
- */
 export const gradesRoutes = (controller) => {
   const router = Router();
   router

--- a/src/backend/src/modules/grade/gradeService.js
+++ b/src/backend/src/modules/grade/gradeService.js
@@ -1,16 +1,6 @@
-// @ts-check
-
 import { HttpError } from "../../exceptions/httpError.js";
-import { GamesRepository } from "../game/gameRepository.js";
-import { UsersRepository } from "../user/userRepository.js";
-import { GradesRepository } from "./gradeRepository.js";
 
 export class GradesService {
-  /**
-   * @param {GradesRepository} gradesRepository
-   * @param {UsersRepository} usersRepository
-   * @param {GamesRepository} gamesRepository
-   */
   constructor(gradesRepository, usersRepository, gamesRepository) {
     this.gradesRepository = gradesRepository;
     this.usersRepository = usersRepository;
@@ -21,28 +11,14 @@ export class GradesService {
     return this.gradesRepository.find();
   }
 
-  /**
-   *
-   * @param {number} id
-   * @returns
-   */
   async findOne(id) {
     return this.gradesRepository.findOne(id);
   }
 
-  /**
-   *
-   * @param {number} userId
-   */
   async findGradesByUser(userId) {
     return this.gradesRepository.findGradesByUser(userId);
   }
 
-  /**
-   *
-   * @param {CreateGradeDto} createGradeDto
-   * @returns
-   */
   async create({ userId, gameId, grade }) {
     const user = await this.usersRepository.findOne(userId);
     if (!user) {
@@ -55,20 +31,10 @@ export class GradesService {
     return this.gradesRepository.create({ userId, gameId, grade });
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdateGradeDto} updateGradeDto
-   * @returns
-   */
   async update(id, { grade }) {
     return this.gradesRepository.update(id, { grade });
   }
 
-  /**
-   *
-   * @param {number} id
-   * @returns
-   */
   async delete(id) {
     return this.gradesRepository.delete(id);
   }

--- a/src/backend/src/modules/platform/dto/createPlatformDto.js
+++ b/src/backend/src/modules/platform/dto/createPlatformDto.js
@@ -1,4 +1,0 @@
-/**
- * @typedef {Object} CreatePlatformDto
- * @property {string} name
- */

--- a/src/backend/src/modules/platform/dto/deletePlatformDto.js
+++ b/src/backend/src/modules/platform/dto/deletePlatformDto.js
@@ -1,5 +1,0 @@
-/**
- * @typedef {Object} deletePlatformDto
- * @property {number} id
-
- */

--- a/src/backend/src/modules/platform/dto/findOnePlatformDto.js
+++ b/src/backend/src/modules/platform/dto/findOnePlatformDto.js
@@ -1,5 +1,0 @@
-/**
- * @typedef {Object} FindOnePlatformDto
- * @property {number} id
-
- */

--- a/src/backend/src/modules/platform/dto/platformDetailDto.js
+++ b/src/backend/src/modules/platform/dto/platformDetailDto.js
@@ -1,8 +1,0 @@
-import Game from "../../game/gameModel.js";
-
-/**
- * @typedef {Object} PlatformDetailDto
- * @property {number} id
- * @property {string} name
- * @property {Game[]} games
- */

--- a/src/backend/src/modules/platform/dto/updatePlatformDto.js
+++ b/src/backend/src/modules/platform/dto/updatePlatformDto.js
@@ -1,5 +1,0 @@
-/**
- * @typedef {Object} UpdatePlatformDto
- * @property {string} name
-
- */

--- a/src/backend/src/modules/platform/platformController.js
+++ b/src/backend/src/modules/platform/platformController.js
@@ -1,27 +1,10 @@
-// @ts-check
-
-import "./dto/createPlatformDto.js";
-import "./dto/findOnePlatformDto.js";
-import "./dto/updatePlatformDto.js";
-import { PlatformsService } from "./platformService.js";
-
 export class PlatformsController {
-  /**
-   *
-   * @param {PlatformsService} service
-   */
   constructor(service) {
     this.service = service;
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async create(req, res, next) {
     try {
-      /**
-       * @type {CreatePlatformDto}
-       */
       const platformDto = req.body;
       const result = await this.service.create(platformDto);
       res.status(201).json(result);
@@ -30,9 +13,6 @@ export class PlatformsController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async addGame(req, res, next) {
     try {
       const { id, gameId } = req.params;
@@ -43,9 +23,6 @@ export class PlatformsController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async find(req, res, next) {
     try {
       const result = await this.service.find();
@@ -55,14 +32,8 @@ export class PlatformsController {
     }
   }
 
-  /**
-   * @type { import('express').RequestHandler}
-   */
   async findOne(req, res, next) {
     try {
-      /**
-       * @param {FindOnePlatformDto} req.params
-       */
       const { id } = req.params;
       const result = await this.service.findOne(Number(id));
       res.status(200).json(result);
@@ -71,18 +42,9 @@ export class PlatformsController {
     }
   }
 
-  /**
-   * @type { import('express').RequestHandler}
-   */
   async update(req, res, next) {
     try {
-      /**
-       * @param {FindOnePlatformDto} req.params
-       */
       const { id } = req.params;
-      /**
-       * @type {UpdatePlatformDto}
-       */
       const { name } = req.body;
       const result = await this.service.update(+id, { name });
       res.status(200).json(result);
@@ -91,14 +53,8 @@ export class PlatformsController {
     }
   }
 
-  /**
-   * @type { import('express').RequestHandler}
-   */
   async delete(req, res, next) {
     try {
-      /**
-       * @param {FindOnePlatformDto} req.params
-       */
       const { id } = req.params;
       const result = await this.service.delete(Number(id));
       res.status(204).send(result);

--- a/src/backend/src/modules/platform/platformModel.js
+++ b/src/backend/src/modules/platform/platformModel.js
@@ -1,13 +1,4 @@
-/**
- * @typedef {Object} PlatformProps
- * @property {number} id
- * @property {string} name
- */
-
 class Platform {
-  /**
-   * @param {PlatformProps} props
-   */
   constructor(props) {
     this.id = props.id;
     this.name = props.name;

--- a/src/backend/src/modules/platform/platformModule.js
+++ b/src/backend/src/modules/platform/platformModule.js
@@ -1,16 +1,9 @@
-// @ts-check
-
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
 import { GamesRepository } from "../game/gameRepository.js";
 import { PlatformsController } from "./platformController.js";
 import { PlatformsRepository } from "./platformRepository.js";
 import { platformsRoutes } from "./platformRoutes.js";
 import { PlatformsService } from "./platformService.js";
 
-/**
- *
- * @param {DatabaseConnection} db
- */
 export const platformsModule = (db) => {
   const repository = new PlatformsRepository(db);
   const gamesRepository = new GamesRepository(db);

--- a/src/backend/src/modules/platform/platformRepository.js
+++ b/src/backend/src/modules/platform/platformRepository.js
@@ -1,39 +1,22 @@
-// @ts-check
-import "./dto/findOnePlatformDto.js";
-import "./dto/createPlatformDto.js";
-import "./dto/updatePlatformDto.js";
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
-import { createPlatformQuery } from "./queries/createPlatform.js";
-import { findPlatformsQuery } from "./queries/findPlatforms.js";
-import { findPlatformGamesQuery } from "./queries/findPlatformGames.js";
-import { updatePlatformQuery } from "./queries/updatePlatform.js";
-import { deletePlatformQuery } from "./queries/deletePlatform.js";
-import { findOnePlatformByNameQuery } from "./queries/findOnePlatformByName.js";
-import Game from "../game/gameModel.js";
 import { createGamePlatformQuery } from "../common/queries/createGamePlatform.js";
+import Game from "../game/gameModel.js";
+import { createPlatformQuery } from "./queries/createPlatform.js";
+import { deletePlatformQuery } from "./queries/deletePlatform.js";
 import { findOnePlatformQuery } from "./queries/findOnePlatform.js";
+import { findOnePlatformByNameQuery } from "./queries/findOnePlatformByName.js";
+import { findPlatformGamesQuery } from "./queries/findPlatformGames.js";
+import { findPlatformsQuery } from "./queries/findPlatforms.js";
+import { updatePlatformQuery } from "./queries/updatePlatform.js";
+
 export class PlatformsRepository {
-  /**
-   * @constructor
-   * @param {DatabaseConnection} db
-   */
   constructor(db) {
     this.db = db;
   }
 
-  /**
-   * @param {CreatePlatformDto} CreatePlatformDto
-   */
   async create({ name }) {
     return await this.db.exec(createPlatformQuery, [name]);
   }
 
-  /**
-   *
-   * @param {number} id
-   * @param {number} gameId
-   * @returns
-   */
   async addGame(id, gameId) {
     const result = await this.db.exec(createGamePlatformQuery, [gameId, id]);
     return result;
@@ -42,10 +25,7 @@ export class PlatformsRepository {
   async find() {
     return await this.db.query(findPlatformsQuery);
   }
-  /**
-   * @param {number} id
-   * @returns {Promise<import("./dto/platformDetailDto.js").PlatformDetailDto>}
-   */
+
   async findOne(id) {
     const platform = await this.db.queryOne(findOnePlatformQuery, [id]);
     const games = await this.db.query(findPlatformGamesQuery, [id]);
@@ -55,25 +35,15 @@ export class PlatformsRepository {
     };
   }
 
-  /**
-   * @param {string} name
-   */
   async findOneByName(name) {
     return this.db.queryOne(findOnePlatformByNameQuery, [name]);
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdatePlatformDto} UpdatePlatformDto
-   */
   async update(id, { name }) {
     const result = await this.db.exec(updatePlatformQuery, [name, id]);
     return result;
   }
 
-  /**
-   * @param {number} id
-   */
   async delete(id) {
     const result = this.db.query(deletePlatformQuery, [id]);
     return result;

--- a/src/backend/src/modules/platform/platformRoutes.js
+++ b/src/backend/src/modules/platform/platformRoutes.js
@@ -1,12 +1,5 @@
-// @ts-check
-
 import { Router } from "express";
-import { PlatformsController } from "./platformController.js";
 
-/**
- *
- * @param {PlatformsController} controller
- */
 export const platformsRoutes = (controller) => {
   const router = Router();
   router

--- a/src/backend/src/modules/platform/platformService.js
+++ b/src/backend/src/modules/platform/platformService.js
@@ -1,26 +1,10 @@
-// @ts-check
-import Platform from "./platformModel.js";
-import { PlatformsRepository } from "./platformRepository.js";
-import "./dto/createPlatformDto.js";
-import "./dto/findOnePlatformDto.js";
 import { HttpError } from "../../exceptions/httpError.js";
-import { GamesRepository } from "../game/gameRepository.js";
 export class PlatformsService {
-  /**
-   *
-   * @param {PlatformsRepository} repository
-   * @param {GamesRepository} gamesRepository
-   */
   constructor(repository, gamesRepository) {
     this.repository = repository;
     this.gamesRepository = gamesRepository;
   }
 
-  /**
-   *
-   * @param {CreatePlatformDto} CreatePlatformDto
-   * @returns
-   */
   async create({ name }) {
     await this.repository.findOneByName(name);
     return this.repository.create({
@@ -28,12 +12,6 @@ export class PlatformsService {
     });
   }
 
-  /**
-   *
-   * @param {number} id
-   * @param {number} gameId
-   * @returns
-   */
   async addGame(id, gameId) {
     await this.repository.findOne(id);
     const game = await this.gamesRepository.findOne(gameId);
@@ -43,16 +21,10 @@ export class PlatformsService {
     return this.repository.addGame(id, gameId);
   }
 
-  /**
-   * @returns {Promise<Platform[]>}
-   */
   async find() {
     return this.repository.find();
   }
 
-  /**
-   * @param {number} id
-   */
   async findOne(id) {
     const platform = await this.repository.findOne(id);
     if (!platform) {
@@ -61,9 +33,6 @@ export class PlatformsService {
     return platform;
   }
 
-  /**
-   * @param {string} name
-   */
   async findOneByName(name) {
     const platform = await this.repository.findOneByName(name);
     if (!platform) {
@@ -72,10 +41,6 @@ export class PlatformsService {
     return platform;
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdatePlatformDto} UpdatePlatformDto
-   */
   async update(id, { name }) {
     const foundPlatform = await this.findOne(id);
     if (foundPlatform.name === name) {
@@ -87,9 +52,6 @@ export class PlatformsService {
     return await this.repository.update(id, { name });
   }
 
-  /**
-   * @param {number} id
-   */
   async delete(id) {
     await this.findOne(id);
     return this.repository.delete(id);

--- a/src/backend/src/modules/user/dto/createUserDto.js
+++ b/src/backend/src/modules/user/dto/createUserDto.js
@@ -1,7 +1,0 @@
-/**
- * @typedef {object} CreateUserDto
- * @property {string} username
- * @property {string} email
- * @property {string} password
- * @property {string} birth_date
- */

--- a/src/backend/src/modules/user/dto/updateUserDto.js
+++ b/src/backend/src/modules/user/dto/updateUserDto.js
@@ -1,4 +1,0 @@
-/**
- * @typedef {object} UpdateUserDto
- * @property {string} password
- */

--- a/src/backend/src/modules/user/userController.js
+++ b/src/backend/src/modules/user/userController.js
@@ -1,24 +1,10 @@
-// @ts-check
-import "./dto/createUserDto.js";
-import "./dto/updateUserDto.js";
-import { UsersService } from "./userService.js";
-
 export class UserController {
-  /**
-   * @param { UsersService } service
-   */
   constructor(service) {
     this.service = service;
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async create(req, res, next) {
     try {
-      /**
-       * @type {CreateUserDto}
-       */
       const userDto = req.body;
       const result = await this.service.create(userDto);
       res.status(201).json(result);
@@ -27,9 +13,6 @@ export class UserController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async find(req, res, next) {
     try {
       const result = await this.service.find();
@@ -39,10 +22,6 @@ export class UserController {
     }
   }
 
-  /**
-   *
-   * @type {import('express').RequestHandler}
-   */
   async findOne(req, res, next) {
     try {
       const { id } = req.params;
@@ -53,9 +32,6 @@ export class UserController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async delete(req, res, next) {
     try {
       const { id } = req.params;
@@ -66,15 +42,9 @@ export class UserController {
     }
   }
 
-  /**
-   * @type {import('express').RequestHandler}
-   */
   async update(req, res, next) {
     try {
       const { id } = req.params;
-      /**
-       * @type {UpdateUserDto}
-       */
       const userDto = req.body;
       const result = await this.service.update(+id, userDto);
       res.status(200).json(result);

--- a/src/backend/src/modules/user/userModel.js
+++ b/src/backend/src/modules/user/userModel.js
@@ -1,17 +1,4 @@
-/**
- * @typedef {object} UserModelProps
- * @property {number} id
- * @property {string} username
- * @property {string} email
- * @property {string} password
- * @property {string} birth_date
- */
-
 class User {
-  /**
-   *
-   * @param {UserModelProps} props
-   */
   constructor(props) {
     this.id = props.id;
     this.username = props.username;

--- a/src/backend/src/modules/user/userRepository.js
+++ b/src/backend/src/modules/user/userRepository.js
@@ -1,8 +1,3 @@
-// @ts-check
-
-import "./dto/createUserDto.js";
-import "./dto/updateUserDto.js";
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
 import { createUserQuery } from "./queries/createUser.js";
 import { deleteUserQuery } from "./queries/deleteUser.js";
 import { findOneByEmailQuery } from "./queries/findOneByEmail.js";
@@ -10,20 +5,12 @@ import { findOneByUsernameQuery } from "./queries/findOneByUsername.js";
 import { findOneUserQuery } from "./queries/findOneUser.js";
 import { findUsers } from "./queries/findUsers.js";
 import { updateUserQuery } from "./queries/updateUser.js";
-import User from "./userModel.js";
 
 export class UsersRepository {
-  /**
-   * @constructor
-   * @param {DatabaseConnection} db
-   */
   constructor(db) {
     this.db = db;
   }
 
-  /**
-   * @param {CreateUserDto} createUserDto
-   */
   async create({ username, email, password, birth_date }) {
     return this.db.exec(createUserQuery, [
       username,
@@ -37,44 +24,22 @@ export class UsersRepository {
     return this.db.query(findUsers);
   }
 
-  /**
-   *
-   * @param {number} userId
-   * @returns {Promise<User>}
-   */
   async findOne(userId) {
     return this.db.queryOne(findOneUserQuery, [userId]);
   }
 
-  /**
-   *
-   * @param {string} email
-   * @returns {Promise<User>}
-   */
   async findOneByEmail(email) {
     return this.db.queryOne(findOneByEmailQuery, [email]);
   }
 
-  /*
-   * @param {string} email
-   * @returns {Promise<User>}
-   * */
   async findOneByUsername(username) {
     return this.db.queryOne(findOneByUsernameQuery, [username]);
   }
 
-  /**
-   *
-   * @param {number} userId
-   */
   async delete(userId) {
     return this.db.exec(deleteUserQuery, [userId]);
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdateUserDto} param1
-   */
   async update(id, { password }) {
     return this.db.exec(updateUserQuery, [password, id]);
   }

--- a/src/backend/src/modules/user/userRoutes.js
+++ b/src/backend/src/modules/user/userRoutes.js
@@ -1,15 +1,8 @@
-// @ts-check
-
 import { Router } from "express";
 import { validationMiddleware } from "../../middleware/validation.js";
 import { validateCreateUser } from "./validation/validateCreateUser.js";
 import { validateUpdateUser } from "./validation/validateUpdateUser.js";
-import { UserController } from "./userController.js";
 
-/**
- *
- * @param {UserController} controller
- */
 export const usersRoutes = (controller) => {
   const usersRoutes = Router();
   usersRoutes

--- a/src/backend/src/modules/user/userService.js
+++ b/src/backend/src/modules/user/userService.js
@@ -1,22 +1,10 @@
-// @ts-check
-
 import { HttpError } from "../../exceptions/httpError.js";
-import "./dto/createUserDto.js";
-import "./dto/updateUserDto.js";
-import { UsersRepository } from "./userRepository.js";
 
 export class UsersService {
-  /**
-   *
-   * @param {UsersRepository} repository
-   */
   constructor(repository) {
     this.repository = repository;
   }
 
-  /**
-   * @param {CreateUserDto} createUserDto
-   */
   async create({ username, email, password, birth_date }) {
     let existingUser = await this.repository.findOneByEmail(email);
     if (existingUser) {
@@ -38,9 +26,6 @@ export class UsersService {
     return this.repository.find();
   }
 
-  /**
-   * @param {number} userId
-   */
   async findOne(userId) {
     const user = await this.repository.findOne(userId);
     if (!user) {
@@ -49,11 +34,6 @@ export class UsersService {
     return user;
   }
 
-  /**
-   *
-   * @param {string} email
-   * @returns
-   */
   async findOneByEmail(email) {
     const user = await this.repository.findOneByEmail(email);
     if (!user) {
@@ -62,11 +42,6 @@ export class UsersService {
     return user;
   }
 
-  /**
-   *
-   * @param {string} username
-   * @returns
-   */
   async findOneByUsername(username) {
     const user = await this.repository.findOneByUsername(username);
     if (!user) {
@@ -75,19 +50,11 @@ export class UsersService {
     return user;
   }
 
-  /**
-   *
-   * @param {number} userId
-   */
   async delete(userId) {
     await this.findOne(userId);
     return this.repository.delete(userId);
   }
 
-  /**
-   * @param {number} id
-   * @param {UpdateUserDto} updateUserDto
-   */
   async update(id, updateUserDto) {
     await this.findOne(id);
     return this.repository.update(id, updateUserDto);

--- a/src/backend/src/modules/user/usersModule.js
+++ b/src/backend/src/modules/user/usersModule.js
@@ -1,15 +1,8 @@
-// @ts-check
-
-import { DatabaseConnection } from "../../infrastructure/database/connection.js";
 import { UserController } from "./userController.js";
 import { UsersRepository } from "./userRepository.js";
 import { usersRoutes } from "./userRoutes.js";
 import { UsersService } from "./userService.js";
 
-/**
- *
- * @param {DatabaseConnection} db
- */
 export const usersModule = (db) => {
   const repository = new UsersRepository(db);
   const service = new UsersService(repository);

--- a/src/backend/src/modules/user/validation/validateCreateUser.js
+++ b/src/backend/src/modules/user/validation/validateCreateUser.js
@@ -1,8 +1,5 @@
 import { ValidationError } from "../../../exceptions/validationError.js";
 
-/**
- * @param {*} body
- */
 export const validateCreateUser = (body) => {
   const { email, password, username, birth_date } = body;
   const errors = {};

--- a/src/backend/src/modules/user/validation/validateUpdateUser.js
+++ b/src/backend/src/modules/user/validation/validateUpdateUser.js
@@ -1,8 +1,5 @@
 import { ValidationError } from "../../../exceptions/validationError.js";
 
-/**
- * @param {*} body
- */
 export const validateUpdateUser = (body) => {
   const { password } = body;
   const errors = {};


### PR DESCRIPTION
Refletindo hoje, fiquei pensando se a decisão de usar JSDocs para tipar as coisas era realmente benéfica. Os benefícios pra desenvolvimento são claros, por conta da inclusão de intellisense. O `// @ts-check` também permite que a gente consiga ver os erros antes de tentar rodar o código, possibilitanto uma experiência parecida com o TypeScript.
Mas ao mesmo tempo, a grande quantidade de comentários no formato JSDoc deixa a sintaxe feia e dificulta a leitura. Resolvi experimentar apagar todos os JSDocs e abrir esse PR como uma forma de estimular a discussão, até porque de fato o código fica muito mais fácil de ler e até de compreender quando retiramos os comentários com JSDocs.